### PR TITLE
install matplotlib -no locked

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ requests = "*"
 urllib3 = "*"
 tensorflow = "*"
 pandas = "*"
+matplotlib = "*"
 
 [requires]
 python_version = "3.7"


### PR DESCRIPTION
I installed matplotlib in my virtual environment. However, `pipenv` failed to add it to `Pipfile.lock` when running `pipenv lock` due to timeout error. This is probably failing because the previous timeout error for `tensorflow`. This is a known issue of `pipenv` (https://github.com/pypa/pipenv/issues/3827#issuecomment-509489806). 

I am creating an issue for this and thinking about other possibilities, like changing to `pip` and `venv` to install the dependencies. 