### PR TITLE
install jupyter notebooks -no lock

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ urllib3 = "*"
 tensorflow = "*"
 pandas = "*"
 matplotlib = "*"
+jupyterlab = {editable = true,git = "git://github.com/jupyterlab/jupyterlab.git"}
 
 [requires]
 python_version = "3.7"


### PR DESCRIPTION
Same as for `matplotlib`, MR #19 

Installed using: `pipenv install -e git+git://github.com/jupyterlab/jupyterlab.git#egg=jupyterlab`