### PR TITLE
increase limit of occurrences in request -default was 20

### DIFF
--- a/data/config.py
+++ b/data/config.py
@@ -10,7 +10,8 @@ images_filter = SearchFilter(
     has_coordinate = "",
     kingdom = "", 
     basis_of_record = "PRESERVED_SPECIMEN",
-    institution_code = "" 
+    institution_code = "", 
+    limit = "50"
 ) 
 geodata_filter = SearchFilter(
     search_name = "Occurrence data from native trees in GB",
@@ -19,7 +20,8 @@ geodata_filter = SearchFilter(
     has_coordinate = "True",
     kingdom = "", 
     basis_of_record = "",
-    institution_code = "" 
+    institution_code = "",
+    limit = "50"
 )
 
 species_list = Species(species_list = native_trees_list())

--- a/data/geodata/geodata_request.py
+++ b/data/geodata/geodata_request.py
@@ -96,10 +96,11 @@ if __name__ == "__main__":
     kingdom = geodata_filter.kingdom  
     basis_of_record = geodata_filter.basis_of_record
     institution_code = geodata_filter.institution_code
+    limit = geodata_filter.limit
     ###############################################
 
     # 2- Handle filter parameters
-    filter = {"mediaType": media_type, "country": country, "hasCoordinate": has_coordinate, "kingdom": kingdom, "basisOfRecord": basis_of_record, "institutionCode": institution_code}
+    filter = {"mediaType": media_type, "country": country, "hasCoordinate": has_coordinate, "kingdom": kingdom, "basisOfRecord": basis_of_record, "institutionCode": institution_code, "limit":limit}
     filter_information = geodata_filter.filter_information()
     ## Hash the filter information + species list string to use it for naming the results file
     filter_hash = filter_hash(geodata_filter, species_list)     

--- a/data/images/image_request/image_request.py
+++ b/data/images/image_request/image_request.py
@@ -103,10 +103,11 @@ if __name__ == "__main__":
     kingdom = images_filter.kingdom  
     basis_of_record = images_filter.basis_of_record
     institution_code = images_filter.institution_code
+    limit = images_filter.limit
     ###############################################
 
     # 2- Handle filter parameters
-    filter = {"mediaType": media_type, "country": country, "hasCoordinate": has_coordinate, "kingdom": kingdom, "basisOfRecord": basis_of_record, "institutionCode": institution_code}
+    filter = {"mediaType": media_type, "country": country, "hasCoordinate": has_coordinate, "kingdom": kingdom, "basisOfRecord": basis_of_record, "institutionCode": institution_code, "limit":limit}
     filter_information = images_filter.filter_information()
     ## Hash the filter information + species list string to use it for naming the results file
     filter_hash = filter_hash(images_filter, species_list)     

--- a/data/search.py
+++ b/data/search.py
@@ -5,7 +5,7 @@ class SearchFilter(object):
     """
     Search parameters in GBIF API.
     """
-    def __init__(self, search_name, media_type, country, has_coordinate, kingdom, basis_of_record, institution_code):
+    def __init__(self, search_name, media_type, country, has_coordinate, kingdom, basis_of_record, institution_code, limit):
         self.search_name = search_name
         self.media_type = media_type  
         self.country = country
@@ -13,6 +13,7 @@ class SearchFilter(object):
         self.kingdom = kingdom  # Plantae
         self.basis_of_record = basis_of_record
         self.institution_code = institution_code # K (RBG Kew)
+        self.limit = limit
 
     def filter_information(self):
         """


### PR DESCRIPTION
Linked to issue #21 
There is a limit in the number of occurrences downloaded per request in GBIF: " In order to retrieve all results for a given search filter you need to issue individual requests for each page, which is limited to a maximum size of 300 records per page" (https://www.gbif.org/developer/occurrence). However, the experience shows that the limit is 20. 

I have added a new parameter to the filter in the query: "limit", and set it up to 50, initially. This new parameter is not added to the filter information, as its purpose it to allow to download the occurrences available.